### PR TITLE
Update step-by-step-guide.md

### DIFF
--- a/docs/thehive/setup/installation/step-by-step-guide.md
+++ b/docs/thehive/setup/installation/step-by-step-guide.md
@@ -562,6 +562,7 @@ By default, TheHive is configured to connect to Cassandra and Elasticsearch data
         cql {
         cluster-name = thp
         keyspace = thehive
+        local-databacenter = datacenter1
         }
     }
     index.search {


### PR DESCRIPTION
Patch doc missing infos.

According tho [this discord message](https://discordapp.com/channels/779945042039144498/953559490840645643/1162026802475176067) (and tested by myself) the configuration need to have the `local-datacenter` key/value to work for the storage in cassandra