### PR TITLE
Move GPG key for packages

### DIFF
--- a/docs/cortex/installation-and-configuration/assets/install.sh
+++ b/docs/cortex/installation-and-configuration/assets/install.sh
@@ -428,19 +428,19 @@ install-thehive() {
   log message "Installing TheHive"
   if [ ${INSTALLTYPE} == "RPM" ]
   then
-      sudo rpm --import https://archives.strangebee.com/keys/strangebee.gpg 
+      sudo rpm --import https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
       cat <<EOF | sudo  tee -a  /etc/yum.repos.d/strangebee.repo
 [thehive]
 enabled=1
 priority=1
 name=StrangeBee RPM repository
 baseurl=https://rpm.strangebee.com/thehive-5.x/noarch
-gpgkey=https://archives.strangebee.com/keys/strangebee.gpg
+gpgkey=https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
 gpgcheck=1
 EOF
   elif [ ${INSTALLTYPE} == "DEB" ]
   then
-    wget -qO- https://archives.strangebee.com/keys/strangebee.gpg |  sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
+    wget -qO- https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key |  sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
     echo 'deb [arch=all signed-by=/usr/share/keyrings/strangebee-archive-keyring.gpg] https://deb.strangebee.com thehive-5.x main' |  sudo tee -a /etc/apt/sources.list.d/strangebee.list
   fi
   if [ $? -ne 0 ]

--- a/docs/thehive/installation/assets/install-deb.sh
+++ b/docs/thehive/installation/assets/install-deb.sh
@@ -201,7 +201,7 @@ EOF
 
 
 ## INSTALL THEHIVE
-wget -qO- https://archives.strangebee.com/keys/strangebee.gpg |  sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
+wget -qO- https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key |  sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
 echo 'deb [arch=all signed-by=/usr/share/keyrings/strangebee-archive-keyring.gpg] https://deb.strangebee.com thehive-5.x main' |  sudo tee -a /etc/apt/sources.list.d/strangebee.list
 
 apt-install thehive

--- a/docs/thehive/installation/assets/install-rpm.sh
+++ b/docs/thehive/installation/assets/install-rpm.sh
@@ -215,7 +215,7 @@ EOF
 
 
 ## INSTALL THEHIVE 
-sudo rpm --import https://archives.strangebee.com/keys/strangebee.gpg 
+sudo rpm --import https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
 
 cat <<EOF | sudo  tee -a  /etc/yum.repos.d/strangebee.repo
 [thehive]
@@ -223,7 +223,7 @@ enabled=1
 priority=1
 name=StrangeBee RPM repository
 baseurl=https://rpm.strangebee.com/thehive-5.x/noarch
-gpgkey=https://archives.strangebee.com/keys/strangebee.gpg
+gpgkey=https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
 gpgcheck=1
 EOF
 

--- a/docs/thehive/installation/step-by-step-installation-guide.md
+++ b/docs/thehive/installation/step-by-step-installation-guide.md
@@ -643,7 +643,7 @@ All required packages are available on our package repository. We support Debian
 
     !!! Example ""
         ```bash
-        wget -O- https://archives.strangebee.com/keys/strangebee.gpg | sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
+        wget -O- https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key | sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
         ```
     
 === "RPM"
@@ -652,7 +652,7 @@ All required packages are available on our package repository. We support Debian
 
     !!! Example ""
         ```bash
-        sudo rpm --import https://archives.strangebee.com/keys/strangebee.gpg 
+        sudo rpm --import https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
         ```
 
 
@@ -674,7 +674,7 @@ Install TheHive package by using the following commands:
 
         !!! Example ""
             ```bash
-            sudo rpm --import https://archives.strangebee.com/keys/strangebee.gpg 
+            sudo rpm --import https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
             ```
 
     2. Create and edit the file /etc/yum.repos.d/strangebee.repo:
@@ -686,7 +686,7 @@ Install TheHive package by using the following commands:
             priority=1
             name=StrangeBee RPM repository
             baseurl=https://rpm.strangebee.com/thehive-5.3/noarch
-            gpgkey=https://archives.strangebee.com/keys/strangebee.gpg
+            gpgkey=https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
             gpgcheck=1
             ```
 

--- a/docs/thehive/installation/upgrade-from-4.x.md
+++ b/docs/thehive/installation/upgrade-from-4.x.md
@@ -411,7 +411,7 @@ If you're utilizing DEB packages for TheHive installation, follow these steps:
     1. **Update Repository Address**: Run the following commands to update the repository address:
 
       ```bash
-      wget -O- https://archives.strangebee.com/keys/strangebee.gpg | sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
+      wget -O- https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key | sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
       sudo rm /etc/apt/sources.list.d/thehive-project.list ; echo 'deb [arch=all signed-by=/usr/share/keyrings/strangebee-archive-keyring.gpg] https://deb.strangebee.com thehive-5.3 main' | sudo tee -a /etc/apt/sources.list.d/strangebee.list
       ```
 
@@ -427,7 +427,7 @@ If you're utilizing DEB packages for TheHive installation, follow these steps:
     1. **Add Cassandra Repository Keys**: Import the Cassandra repository keys with the following command:
 
         ```bash
-        sudo rpm --import https://archives.strangebee.com/keys/strangebee.gpg
+        sudo rpm --import https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
         ```
 
     2. **Configure RPM Repository**: Create and edit the file /etc/yum.repos.d/strangebee.repo with the following content:
@@ -438,7 +438,7 @@ If you're utilizing DEB packages for TheHive installation, follow these steps:
         priority=1
         name=StrangeBee RPM repository
         baseurl=https://rpm.strangebee.com/thehive-5.3/noarch
-        gpgkey=https://archives.strangebee.com/keys/strangebee.gpg
+        gpgkey=https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
         gpgcheck=1
         ```
 

--- a/docs/thehive/installation/upgrade-from-5.x.md
+++ b/docs/thehive/installation/upgrade-from-5.x.md
@@ -30,7 +30,7 @@ TheHive 5.x deliverables are hosted in distinct package repositories. Depending 
     1. (Optional) Install the package repository signature key, if not already installed:
 
         ```bash
-        wget -O- https://archives.strangebee.com/keys/strangebee.gpg | sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
+        wget -O- https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key | sudo gpg --dearmor -o /usr/share/keyrings/strangebee-archive-keyring.gpg
         ```
 
     2. Edit the file ``/etc/apt/sources.list.d/strangebee.list`` and adjust the repository address as follows:
@@ -51,7 +51,7 @@ TheHive 5.x deliverables are hosted in distinct package repositories. Depending 
     1. (Optional) Install the package repository signature key, if not already installed:
 
         ```bash
-        sudo rpm --import https://archives.strangebee.com/keys/strangebee.gpg
+        sudo rpm --import https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
         ```
 
     2. Edit the file ``/etc/yum.repos.d/strangebee.repo`` and adjust the repository address as follows:
@@ -62,7 +62,7 @@ TheHive 5.x deliverables are hosted in distinct package repositories. Depending 
         priority=1
         name=StrangeBee RPM repository
         baseurl=https://rpm.strangebee.com/thehive-5.3/noarch
-        gpgkey=https://archives.strangebee.com/keys/strangebee.gpg
+        gpgkey=https://raw.githubusercontent.com/StrangeBeeCorp/Security/main/PGP%20keys/packages.key
         gpgcheck=1
         ``` 
 


### PR DESCRIPTION
Move GPG key used for packages from package repository to GitHub security repository.