### PR TITLE
fix: Fixing link to Docker install instructions

### DIFF
--- a/docs/thehive/download/index.md
+++ b/docs/thehive/download/index.md
@@ -31,7 +31,7 @@ If you are running an operating system based on RedHat or Fedora, TheHive can be
 
 If you prefer using Docker, you can leverage pre-built Docker images available on Docker Hub for convenient deployment and containerization of TheHive. 
 
-The Docker image can be found on [**TheHive Docker Hub**](https://hub.docker.com/r/strangebee/TheHive), and [**instructions to run it can be found here**](../installation/docker/docker.md). These steps will guide you through the necessary configurations and prerequisites to get TheHive fully operational.
+The Docker image can be found on [**TheHive Docker Hub**](https://hub.docker.com/r/strangebee/TheHive), and [**instructions to run it can be found here**](../installation/docker.md). These steps will guide you through the necessary configurations and prerequisites to get TheHive fully operational.
 
 &nbsp;
 


### PR DESCRIPTION
On the "Download" page, in the "Docker" section, the link to the instructions to run TheHive , using the official Docker image, is incorrect.

<img width="1172" alt="download-docker-instructions" src="https://github.com/user-attachments/assets/b19fd258-2134-4f1f-b8c1-b02f98407ae6">

&nbsp;

Current link is: `https://docs.strangebee.com/thehive/installation/docker/docker.md`. It leads to a `404`

<img width="1257" alt="docker-instructions-404" src="https://github.com/user-attachments/assets/2fc7347d-9bc2-4ee6-977e-4978bc617cce">

&nbsp;
**Correct value is: `https://docs.strangebee.com/thehive/installation/docker.md`**
