### PR TITLE
feat(workflow): add pr-preview job

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -1,28 +1,66 @@
-name: ci 
+---
+
+name: Deploy doc in production
+
 on:
   push:
     branches:
       - main
+
+concurrency: deploy-doc
+
 permissions:
   contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v4
+
+      - name: Define cache_id
+        run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+
+      - name: Setup cache
+        uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install -r requirements.txt
-      - run: mkdocs gh-deploy --force
+
+      - name: Install python requirements.txt
+        run: pip install -r requirements.txt
+
+      - name: Build doc
+        run: mkdocs build
+
+      - name: Clone branch gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages  # clone in $GITHUB_WORKSPACE/gh-pages/
+
+      - name: Copy build results
+        run: |
+          rsync -av \
+            --delete \
+            --checksum \
+            --exclude .git/ \
+            --exclude pr-preview/ \
+            site/ $GITHUB_WORKSPACE/gh-pages/
+
+      - name: Commit and push
+        run: |
+          cd $GITHUB_WORKSPACE/gh-pages/
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add -A
+          git commit -m "Auto build/deploy docs from main branch"
+          git push --force origin gh-pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,37 @@
+---
+
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install and Build
+        if: github.event.action != 'closed'
+        run: |
+          pip install -r requirements.txt
+          mkdocs build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/
+          preview-branch: gh-pages

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -10,7 +10,7 @@ on:
       - synchronize
       - closed
 
-concurrency: preview-${{ github.ref }}
+concurrency: deploy-doc
 
 jobs:
   deploy-preview:

--- a/README.md
+++ b/README.md
@@ -97,3 +97,6 @@ If not:
 mkdocs gh-deploy --remote-branch gh-pages
 ```
 
+:bulb: please also note that each PR is temporary deployed to `docs.strangebee.com/pr-preview/pr-${PR_ID}/`.
+This environment is automatically created and dropped when the PR is closed or
+merged!


### PR DESCRIPTION
done in this PR 💁  :
* PR is automatically deployed (eg for this PR which is deployed [on specific subpath](https://docs.strangebee.com/pr-preview/pr-154/))
* when the PR is merged/closed, the env is dropped
* change the behavior of the main workflow by keeping the history of the branch `gh-pages` and avoid to remove the `pr-preview` directory

won't do 🙅  :
* rebrand and refacto the workflows (with a composite action)
* fix the cache warnings
* add more ci checks (such as yaml, hadolint, etc...)
* update the docker image to avoid `pip install` for each job + pin all python requirements