### PR TITLE
DOC-172

### DIFF
--- a/docs/cortex/installation-and-configuration/index.md
+++ b/docs/cortex/installation-and-configuration/index.md
@@ -1,6 +1,5 @@
 # Installation & configuration guides
 
-
 ## Overview
 Cortex relies on Elasticsearch to store its data. A basic setup to install Elasticsearch, then Cortex on a standalone and dedicated server (physical or virtual).
 
@@ -10,7 +9,6 @@ Hardware requirements depends on the usage of the system. We recommend starting 
   * :fontawesome-solid-microchip: 8 vCPU
   * :fontawesome-solid-memory: 16 GB of RAM
 
-
 ## Operating systems
 Cortex has been tested and is supported on the following operating systems: 
 
@@ -19,7 +17,7 @@ Cortex has been tested and is supported on the following operating systems:
 - :material-redhat: RHEL 8
 - :material-fedora: Fedora 35
 
-## Installation Guide
+## Installation guide
 
 !!! Tip "Too much in a hurry to read ? "
 
@@ -47,7 +45,7 @@ For each release, DEB, RPM and ZIP binary packages are built and provided.
 
 The [following Guide](step-by-step-guide.md) let you **prepare**, **install** and **configure** Cortex and its prerequisites for Debian and RPM packages based Operating Systems, as well as for other systems and using our binary packages. 
 
-## Configuration Guides
+## Configuration guides
 
 The configuration of Cortex is in files stored in the `/etc/cortex` folder:
     

--- a/docs/cortex/installation-and-configuration/step-by-step-guide.md
+++ b/docs/cortex/installation-and-configuration/step-by-step-guide.md
@@ -1,4 +1,4 @@
-# Step-by-Step guide
+# Step-by-Step Guide
 
 This page is a step by step installation and configuration guide to get a Cortex instance up and running. This guide is illustrated with examples for Debian and RPM packages based systems and for installation from binary packages.
 
@@ -191,7 +191,7 @@ Cortex is available in Debian, RPM, and binary (zip archive) formats. All packag
 0CD5 AC59 DE5C 5A8E 0EE1  3849 3D99 BB18 562C BC1C
 ```
 
-### Debian-based Installation
+### Debian-based installation
 
 Ensure your system is up to date before installing Cortex. Run the following commands:
 
@@ -212,7 +212,7 @@ sudo apt update
 sudo apt install cortex
 ```
 
-### RPM-based Installation
+### RPM-based installation
 
 For RPM-based distributions (CentOS, RHEL, Fedora), create a new repository configuration file:
 
@@ -234,7 +234,7 @@ Then, install Cortex:
 sudo yum install cortex
 ```
 
-### Binary Installation
+### Binary installation
 
 For environments where package managers are not available, download and extract the Cortex binary package:
 
@@ -245,7 +245,7 @@ cd /opt/cortex
 chmod +x cortex
 ```
 
-## Post-Installation Configuration
+## Post-Installation configuration
 
 ### Running Analyzers & Responders with Docker
 
@@ -255,7 +255,7 @@ If you plan to use Cortex with _Analyzers & Responders_ running in Docker, ensur
 sudo usermod -a -G docker cortex
 ```
 
-### Verify Installation
+### Verify installation
 
 After installation, you can check if Cortex is properly installed by running:
 

--- a/docs/cortex/installation-and-configuration/step-by-step-guide.md
+++ b/docs/cortex/installation-and-configuration/step-by-step-guide.md
@@ -25,7 +25,7 @@ This page is a step by step installation and configuration guide to get a Cortex
 
 !!! example "Install Java"
 
-    For enhanced security and long-term support, we recommend using [**Amazon Corretto**](https://aws.amazon.com/corretto/), an OpenJDK build provided and maintained by Amazon.
+    For enhanced security and long-term support, we recommend using [Amazon Corretto](https://aws.amazon.com/corretto/), an OpenJDK build provided and maintained by Amazon. Corretto 11 or higher is required to install Cortex.
 
     === "DEB"
 

--- a/docs/cortex/user-guides/first-start.md
+++ b/docs/cortex/user-guides/first-start.md
@@ -1,10 +1,11 @@
 # Quick Start Guide
-This is the Quick Start guide for Cortex 3. It assumes that Cortex [has been installed](../installation-and-configuration/step-by-step-guide.md), and that [the analyzers](../installation-and-configuration/analyzers-responders.md) have been installed as well.
+
+This is the quick start guide for Cortex 3. It assumes that Cortex [has been installed](../installation-and-configuration/step-by-step-guide.md), and that [the analyzers](../installation-and-configuration/analyzers-responders.md) have been installed as well.
 
 ## Step 1: Connect to Cortex
 One Cortex is installed and configured, open your web browser and connect to http://cortexaddress:9001. 
 
-## Step 2: Update the Database
+## Step 2: Update the database
 Cortex uses ElasticSearch to store users, organizations and analyzers configuration. The first time you connect to the Web UI (`http://<CORTEX_IP>:9001` by default), you have to create the database by clicking the `Update Database` button.
 
 ![Update Database](images/update.png)
@@ -18,13 +19,13 @@ You will then be able to log in using this user account. You will note that the 
 
 ![Cortex administrator Account](images/cortex_admin_login.png)
 
-## Step 4: Create an Organization
+## Step 4: Create an organization
 
 The default `cortex` organization cannot be used for any other purpose than managing global administrators (users with the `superAdmin` role), organizations and their associated users. It cannot be used to enable/disable or configure analyzers. To do so, you need to create your own organization inside Cortex by clicking on the `Add organization`  button.
 
 ![Add Organization](images/new_org.png)
 
-## Step 5: Create a Organization Administrator
+## Step 5: Create a organization Administrator
 
 Create the organization administrator account (user with an `orgAdmin` role).
 
@@ -32,10 +33,10 @@ Create the organization administrator account (user with an `orgAdmin` role).
 
 Then, specify a password for this user. After doing so,  log out and log in with that new user account.
 
-## Step 6: Enable and Configure Analyzers
+## Step 6: Enable and configure Analyzers
 Enable the analyzers you need, configure them using the **Organization** > **Configuration** and **Organization** > **Analyzers** tabs. All analyzer configuration is done using the Web UI, including adding API keys and configuring rate limits.
 
-## Step 7 (Optional): Create an Account for TheHive integration
+## Step 7 (Optional): Create an account for TheHive integration
 
 If you are using TheHive, create a new account inside your organization with the `read, analyze` role and generate an API key that you will need to add to TheHive's configuration.
 


### PR DESCRIPTION
Toom mentioned that OpenJDK should be installed using Amazon Corretto. Therefore, I wrote that we recommend using Amazon Corretto 11 or higher for installing Cortex, rather than OpenJDK 11+.