### PR TITLE
fix(cortex): missing gpg --dearmor option in doc

### DIFF
--- a/docs/cortex/installation-and-configuration/step-by-step-guide.md
+++ b/docs/cortex/installation-and-configuration/step-by-step-guide.md
@@ -196,7 +196,7 @@ Cortex is available in Debian, RPM, and binary (zip archive) formats. All packag
 Ensure your system is up to date before installing Cortex. Run the following commands:
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/TheHive-Project/Cortex/master/PGP-PUBLIC-KEY | sudo gpg --dearmor -o /usr/share/keyrings/thehive-project.gpg > /dev/null
+curl -sSL https://raw.githubusercontent.com/TheHive-Project/Cortex/master/PGP-PUBLIC-KEY | sudo gpg --dearmor -o /usr/share/keyrings/thehive-project.gpg
 ```
 
 Add the repository to your system:


### PR DESCRIPTION
💡 This PR aims at correcting an issue with Cortex package installation (deb).

🛡️ The doc does not mention we need to use `--dearmor` on gpg key before `apt update` is run.

⚠️ **Details**:
* wget replaced by curl to follow most of recent usages (using silent but showing errors in case of + follow redirections)
* gpg key needs to be `--dearmored` to be used as a binary

🐳 Tested in Debian 12.10 Docker container, vanilla.
Simply followed the current doc instructions to solve this.