### PR TITLE
Dearmor gpg key to work with apt

### DIFF
--- a/docs/cortex/installation-and-configuration/step-by-step-guide.md
+++ b/docs/cortex/installation-and-configuration/step-by-step-guide.md
@@ -196,7 +196,7 @@ Cortex is available in Debian, RPM, and binary (zip archive) formats. All packag
 Ensure your system is up to date before installing Cortex. Run the following commands:
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/TheHive-Project/Cortex/master/PGP-PUBLIC-KEY | sudo tee /usr/share/keyrings/thehive-project.gpg > /dev/null
+wget -qO- https://raw.githubusercontent.com/TheHive-Project/Cortex/master/PGP-PUBLIC-KEY | sudo gpg --dearmor -o /usr/share/keyrings/thehive-project.gpg
 ```
 
 Add the repository to your system:


### PR DESCRIPTION
APT requires a dearmored GPG key